### PR TITLE
use testthat version 3+

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,6 +57,6 @@ Suggests:
     xml2
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1.9001
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,3 +59,4 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1.9001
 VignetteBuilder: knitr
+Config/testthat/edition: 3

--- a/man/munch-package.Rd
+++ b/man/munch-package.Rd
@@ -13,9 +13,7 @@ municipality IDs, and to construct mappings between two lists of municipality
 IDs.  The package provides functions to import and work with this mutation
 list.
 
-Contains historicized municipality data for
-    Switzerland from 1960 onwards, from the "Historisiertes
-    Gemeindeverzeichnis" of the Swiss Federal Statistical Office.
+Contains historicized municipality data for Switzerland from 1960 onwards, from the "Historisiertes Gemeindeverzeichnis" of the Swiss Federal Statistical Office.
 }
 \details{
 \tabular{ll}{

--- a/tests/testthat/test-mapping.R
+++ b/tests/testthat/test-mapping.R
@@ -1,13 +1,11 @@
-context("mapping")
-
 test_that("mapping returns integer columns", {
   mapping <- swc_get_mapping(ids_from = 500, ids_to = 2875)
 
-  expect_is(mapping$mHistId.from, "integer")
-  expect_is(mapping$mId.from, "integer")
+  expect_type(mapping$mHistId.from, "integer")
+  expect_type(mapping$mId.from, "integer")
   expect_null(mapping$mIdAsNumber.from)
-  expect_is(mapping$mHistId.to, "integer")
-  expect_is(mapping$mId.to, "integer")
+  expect_type(mapping$mHistId.to, "integer")
+  expect_type(mapping$mId.to, "integer")
   expect_null(mapping$mIdAsNumber.to)
 })
 
@@ -17,12 +15,12 @@ test_that("mapping returns factors for factor input", {
     ids_to = factor(2875)
   )
 
-  expect_is(mapping$mHistId.from, "integer")
-  expect_is(mapping$mId.from, "factor")
-  expect_is(mapping$mIdAsNumber.from, "integer")
-  expect_is(mapping$mHistId.to, "integer")
-  expect_is(mapping$mId.to, "factor")
-  expect_is(mapping$mIdAsNumber.to, "integer")
+  expect_type(mapping$mHistId.from, "integer")
+  expect_true(class(mapping$mId.from) == "factor")
+  expect_type(mapping$mIdAsNumber.from, "integer")
+  expect_type(mapping$mHistId.to, "integer")
+  expect_true(class(mapping$mId.to) == "factor")
+  expect_type(mapping$mIdAsNumber.to, "integer")
 })
 
 test_that("deprecation error", {


### PR DESCRIPTION
needed a little workaround for checking if a type is `factor`, cause `expect_type()` uses `type_of` and:
``` r
factor_var <- factor(c(1,2))
testthat::expect_type(factor_var, "factor")
#> Error: `factor_var` has type 'integer', not 'factor'.
typeof(factor_var)
#> [1] "integer"
```

<sup>Created on 2021-12-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

closes #48 